### PR TITLE
offset border problem

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamSource.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamSource.scala
@@ -126,7 +126,7 @@ class JDBCStreamSource(
     }
 
     val strFilter =
-      s"$offsetColumn >= CAST('$s' AS ${offsetColumnType.sql}) and $offsetColumn < CAST('$e' AS ${offsetColumnType.sql})"
+      s"$offsetColumn >= CAST('$s' AS ${offsetColumnType.sql}) and $offsetColumn <= CAST('$e' AS ${offsetColumnType.sql})"
 
     val filteredDf = df.where(strFilter)
     val rdd = filteredDf.queryExecution.toRdd


### PR DESCRIPTION
```
    val startOffsets = start match {
      case Some(prevBatchEndOffset) =>
        prevBatchEndOffset.json().toLong + 1
      case None =>
        initialOffsets.offset
    }
```
Your code shows start offset increments by 1 for each batch. So the max value of previous will be lost according to ` s"$offsetColumn >= CAST('$s' AS ${offsetColumnType.sql}) and $offsetColumn < CAST('$e' AS ${offsetColumnType.sql})"`

If I'm not wrong we should add the upper border also.